### PR TITLE
fix: initialize swisstopo full color style at startup

### DIFF
--- a/lib/features/map/data/swisstopo_styles.dart
+++ b/lib/features/map/data/swisstopo_styles.dart
@@ -1,12 +1,20 @@
+import 'package:flutter/services.dart';
 import 'package:touringbuddy_frontend/features/map/domain/base_map_style.dart';
 
 class SwisstopoStyles {
   static const String base =
       'https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json';
-  static const String fullColor = 'assets/swisstopo_wmts_style.json';
+  static String _fullColorJson = '';
+  static String get fullColor => _fullColorJson;
 
   static final List<BaseMapStyle> all = [
     const BaseMapStyle('Base', base),
-    const BaseMapStyle('Full Color', fullColor),
+    BaseMapStyle('Full Color', _fullColorJson),
   ];
+
+  static Future<void> initialize() async {
+    _fullColorJson = await rootBundle.loadString(
+      'assets/swisstopo_wmts_style.json',
+    );
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:touringbuddy_frontend/core/config/theme.dart';
+import 'package:touringbuddy_frontend/features/map/data/swisstopo_styles.dart';
 import 'package:touringbuddy_frontend/pages/auth_gate.dart';
 import 'package:touringbuddy_frontend/providers/contacts_service.dart';
 import 'package:touringbuddy_frontend/providers/tours_service.dart';
@@ -30,6 +31,8 @@ final GlobalKey<ScaffoldMessengerState> rootMessengerKey =
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeSupabase();
+  await SwisstopoStyles.initialize();
+
   runApp(
     MultiProvider(
       providers: [


### PR DESCRIPTION
## 📝 Description

Initialize the Swisstopo full map style at startup as JSON string.

### 🚀 Features / Changes Made

- Load JSON at startup to hopefully display it nicely

## 🧪 Quality Checklist

- [x] I have read the [**contribution guidelines**](../README.md#guidelines-for-contributions) for this project.
- [x] I have performed a self-review of my own code.
- [x] `flutter analyze` passes locally with no warnings.
- [x] I have added/updated unit or widget tests (if applicable).
- [x] My changes generate no new errors in the browser console.
